### PR TITLE
fix mentions of -demo repo which seems to no longer be

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Clone both the SDK and the demo application repositories:
 
 ```bash
 git clone https://github.com/discoverfinancial/fin-ocr-sdk.git
-git clone https://github.com/discoverfinancial/fin-ocr-browser-demo.git
+git clone https://github.com/discoverfinancial/fin-ocr-browser.git
 ```
 
 ### 2. Build and Link the SDK
@@ -83,10 +83,10 @@ If the normal global path for npm is restricted on your corporate machine, you c
 </details>
 
 ### 3. Install Dependencies and Build the Demo Application
-Next, navigate to the fin-ocr-browser-demo directory and run the following commands to install the necessary dependencies and build the project:
+Next, navigate to the fin-ocr-browser directory and run the following commands to install the necessary dependencies and build the project:
 
 ```bash
-cd ../fin-ocr-browser-demo
+cd ../fin-ocr-browser
 npm link @discoverfinancial/fin-ocr-sdk
 npm run build
 ```


### PR DESCRIPTION
I'm guessing somewhere along the way that the fin-ocr-browser-demo repo was renamed the fin-ocr-browser repo but the README wasn't updated to reflect that.  This PR addresses that.